### PR TITLE
MYRIAD-137: Decline cached offers when a zero-profile NM shutsdown.

### DIFF
--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/StatusUpdateEventHandler.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/StatusUpdateEventHandler.java
@@ -16,15 +16,15 @@
 package com.ebay.myriad.scheduler.event.handlers;
 
 import com.ebay.myriad.scheduler.event.StatusUpdateEvent;
+import com.ebay.myriad.scheduler.fgs.OfferLifecycleManager;
 import com.ebay.myriad.state.SchedulerState;
 import com.lmax.disruptor.EventHandler;
+import javax.inject.Inject;
 import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.Protos.TaskState;
 import org.apache.mesos.Protos.TaskStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
 
 /**
  * handles and logs mesos status update events
@@ -33,8 +33,14 @@ public class StatusUpdateEventHandler implements EventHandler<StatusUpdateEvent>
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StatusUpdateEventHandler.class);
 
+    private final SchedulerState schedulerState;
+    private final OfferLifecycleManager offerLifecycleManager;
+
     @Inject
-    private SchedulerState schedulerState;
+    public StatusUpdateEventHandler(SchedulerState schedulerState, OfferLifecycleManager offerLifecycleManager) {
+      this.schedulerState = schedulerState;
+      this.offerLifecycleManager = offerLifecycleManager;
+    }
 
     @Override
     public void onEvent(StatusUpdateEvent event,
@@ -44,10 +50,10 @@ public class StatusUpdateEventHandler implements EventHandler<StatusUpdateEvent>
         this.schedulerState.updateTask(status);
         TaskID taskId = status.getTaskId();
         if (!schedulerState.hasTask(taskId)) {
-            LOGGER.warn("Task: {} not found, status: {}", taskId, status.getState());
+            LOGGER.warn("Task: {} not found, status: {}", taskId.getValue(), status.getState());
             return;
         }
-        LOGGER.info("Status Update for task: {} | state: {}", taskId, status.getState());
+        LOGGER.info("Status Update for task: {} | state: {}", taskId.getValue(), status.getState());
         TaskState state = status.getState();
 
         switch (state) {
@@ -61,16 +67,20 @@ public class StatusUpdateEventHandler implements EventHandler<StatusUpdateEvent>
                 schedulerState.makeTaskActive(taskId);
                 break;
             case TASK_FINISHED:
+                offerLifecycleManager.declineOutstandingOffers(schedulerState.getTask(taskId).getHostname());
                 schedulerState.removeTask(taskId);
                 break;
             case TASK_FAILED:
                 // Add to pending tasks
-                schedulerState.makeTaskPending(taskId);
+              offerLifecycleManager.declineOutstandingOffers(schedulerState.getTask(taskId).getHostname());
+              schedulerState.makeTaskPending(taskId);
                 break;
             case TASK_KILLED:
+              offerLifecycleManager.declineOutstandingOffers(schedulerState.getTask(taskId).getHostname());
                 schedulerState.removeTask(taskId);
                 break;
             case TASK_LOST:
+              offerLifecycleManager.declineOutstandingOffers(schedulerState.getTask(taskId).getHostname());
                 schedulerState.makeTaskPending(taskId);
                 break;
             default:

--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/fgs/OfferLifecycleManager.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/fgs/OfferLifecycleManager.java
@@ -8,6 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Inject;
 
 import org.apache.mesos.Protos;
+import org.apache.mesos.Protos.Offer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,5 +83,18 @@ public class OfferLifecycleManager {
 
   public ConsumedOffer drainConsumedOffer(String hostname) {
     return consumedOfferMap.remove(hostname);
+  }
+
+  public void declineOutstandingOffers(String hostname) {
+    int numOutStandingOffers = 0;
+    OfferFeed offerFeed = getOfferFeed(hostname);
+    Offer offer;
+    while (offerFeed != null && (offer = offerFeed.poll()) != null) {
+      declineOffer(offer);
+      numOutStandingOffers++;
+    }
+    if (numOutStandingOffers > 0) {
+      LOGGER.info("Declined {} outstanding offers for host {}", numOutStandingOffers, hostname);
+    }
   }
 }


### PR DESCRIPTION
- Added a method to OfferLifeCycleManager to decline all outstanding offers for a specific hostname.
- When NMs are flexed down and on receiving TASK_{KILLED,FINISHED,LOST}, the above method is invoked to clear out any outstanding mesos offers cached with Myriad.
