### PR TITLE
This commit address Myriad-135, it is possible an offer may not conta…

### DIFF
--- a/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
+++ b/myriad-scheduler/src/main/java/com/ebay/myriad/scheduler/event/handlers/ResourceOffersEventHandler.java
@@ -26,7 +26,13 @@ import com.ebay.myriad.state.NodeTask;
 import com.ebay.myriad.state.SchedulerState;
 import com.lmax.disruptor.EventHandler;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.mesos.Protos;
 import org.apache.mesos.Protos.Offer;
@@ -40,11 +46,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -55,6 +56,12 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
   private static final Logger LOGGER = LoggerFactory.getLogger(ResourceOffersEventHandler.class);
 
   private static final Lock driverOperationLock = new ReentrantLock();
+
+  private static final String RESOURCES_CPU_KEY = "cpus";
+  private static final String RESOURCES_MEM_KEY = "mem";
+  private static final String RESOURCES_PORTS_KEY = "ports";
+  private static final String RESOURCES_DISK_KEY = "disk";
+
 
   @Inject
   private SchedulerState schedulerState;
@@ -84,14 +91,14 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
         if (CollectionUtils.isNotEmpty(pendingTasks)) {
           for (Protos.TaskID pendingTaskId : pendingTasks) {
             NodeTask taskToLaunch = schedulerState
-                .getTask(pendingTaskId);
+                    .getTask(pendingTaskId);
             NMProfile profile = taskToLaunch.getProfile();
 
             if (matches(offer, profile)
-                && SchedulerUtils.isUniqueHostname(offer,
-                schedulerState.getActiveTasks())) {
+                    && SchedulerUtils.isUniqueHostname(offer,
+                    schedulerState.getActiveTasks())) {
               TaskInfo task = taskFactory.createTask(offer, schedulerState.getFrameworkID(), pendingTaskId,
-                  taskToLaunch);
+                      taskToLaunch);
 
               List<OfferID> offerIds = new ArrayList<>();
               offerIds.add(offer.getId());
@@ -121,7 +128,7 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
         if (SchedulerUtils.isEligibleForFineGrainedScaling(offer.getHostname(), schedulerState)) {
           if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Picking an offer from slave with hostname {} for fine grained scaling.",
-                offer.getHostname());
+                    offer.getHostname());
           }
           offerLifecycleMgr.addOffers(offer);
         } else {
@@ -138,22 +145,27 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
 
   private boolean matches(Offer offer, NMProfile profile) {
     Map<String, Object> results = new HashMap<String, Object>(5);
+    //Assign default values to avoid NPE
+    results.put(RESOURCES_CPU_KEY, Double.valueOf(0.0));
+    results.put(RESOURCES_MEM_KEY, Double.valueOf(0.0));
+    results.put(RESOURCES_DISK_KEY, Double.valueOf(0.0));
+    results.put(RESOURCES_PORTS_KEY, Integer.valueOf(0));
 
     for (Resource resource : offer.getResourcesList()) {
       if (resourceEvaluators.containsKey(resource.getName())) {
         resourceEvaluators.get(resource.getName()).eval(resource, results);
       } else {
         LOGGER.warn("Ignoring unknown resource type: {}",
-            resource.getName());
+                resource.getName());
       }
     }
-    double cpus = (Double) results.get("cpus");
-    double mem = (Double) results.get("mem");
-    int ports = (Integer) results.get("ports");
+    double cpus = (Double) results.get(RESOURCES_CPU_KEY);
+    double mem = (Double) results.get(RESOURCES_MEM_KEY);
+    int ports = (Integer) results.get(RESOURCES_PORTS_KEY);
 
-    checkResource(cpus < 0, "cpus");
-    checkResource(mem < 0, "mem");
-    checkResource(ports < 0, "port");
+    checkResource(cpus <= 0, RESOURCES_CPU_KEY);
+    checkResource(mem <= 0, RESOURCES_MEM_KEY);
+    checkResource(ports <= 0, RESOURCES_PORTS_KEY);
 
     return checkAggregates(offer, profile, ports, cpus, mem);
   }
@@ -164,17 +176,18 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
     }
   }
 
+
   private boolean checkAggregates(Offer offer, NMProfile profile, int ports, double cpus, double mem) {
     Map<String, String> requestAttributes = new HashMap<>();
 
     if (taskUtils.getAggregateCpus(profile) <= cpus
-        && taskUtils.getAggregateMemory(profile) <= mem
-        && SchedulerUtils.isMatchSlaveAttributes(offer, requestAttributes)
-        && NMPorts.expectedNumPorts() <= ports) {
+            && taskUtils.getAggregateMemory(profile) <= mem
+            && SchedulerUtils.isMatchSlaveAttributes(offer, requestAttributes)
+            && NMPorts.expectedNumPorts() <= ports) {
       return true;
     } else {
       LOGGER.info("Offer not sufficient for task with, cpu: {}, memory: {}, ports: {}",
-          taskUtils.getAggregateCpus(profile), taskUtils.getAggregateMemory(profile), ports);
+              taskUtils.getAggregateCpus(profile), taskUtils.getAggregateMemory(profile), ports);
       return false;
     }
   }
@@ -185,7 +198,7 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
       value = new Double(resource.getScalar().getValue());
     } else {
       LOGGER.error(id + " resource was not a scalar: {}", resource
-          .getType().toString());
+              .getType().toString());
     }
     return value;
   }
@@ -198,21 +211,23 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
 
   static {
     resourceEvaluators = new HashMap<String, EvalResources>(4);
-    resourceEvaluators.put("cpus", new EvalResources() {
+    resourceEvaluators.put(RESOURCES_CPU_KEY, new EvalResources() {
       public void eval(Resource resource, Map<String, Object> results) {
-        results.put("cpus", scalarToDouble(resource, "cpus"));
+        results.put(RESOURCES_CPU_KEY, (Double) results.get(RESOURCES_CPU_KEY) +
+                scalarToDouble(resource, RESOURCES_CPU_KEY));
       }
     });
-    resourceEvaluators.put("mem", new EvalResources() {
+    resourceEvaluators.put(RESOURCES_MEM_KEY, new EvalResources() {
       public void eval(Resource resource, Map<String, Object> results) {
-        results.put("mem", scalarToDouble(resource, "mem"));
+        results.put(RESOURCES_MEM_KEY, (Double) results.get(RESOURCES_MEM_KEY) +
+                scalarToDouble(resource, RESOURCES_MEM_KEY));
       }
     });
-    resourceEvaluators.put("disk", new EvalResources() {
+    resourceEvaluators.put(RESOURCES_DISK_KEY, new EvalResources() {
       public void eval(Resource resource, Map<String, Object> results) {
       }
     });
-    resourceEvaluators.put("ports", new EvalResources() {
+    resourceEvaluators.put(RESOURCES_PORTS_KEY, new EvalResources() {
       public void eval(Resource resource, Map<String, Object> results) {
         int ports = 0;
         if (resource.getType().equals(Value.Type.RANGES)) {
@@ -222,13 +237,13 @@ public class ResourceOffersEventHandler implements EventHandler<ResourceOffersEv
               ports += range.getEnd() - range.getBegin() + 1;
             }
           }
-
         } else {
           LOGGER.error("ports resource was not Ranges: {}", resource
-              .getType().toString());
+                  .getType().toString());
 
         }
-        results.put("ports", Integer.valueOf(ports));
+        results.put(RESOURCES_PORTS_KEY, (Integer) results.get(RESOURCES_PORTS_KEY) +
+                Integer.valueOf(ports));
       }
     });
   }


### PR DESCRIPTION
…in a particular resource type, in which case an NPE occured.

In reviewing the code it was also discovered Myriad was only taking the first resource type offered instead of all resources of a type offered.  This meant if Myriad was running with role "Hadoop" and got an offer with cpu(Hadoop): 2 and cpu(*): 1, it would ignore the 1 cpu it could've taken from the * role.