### PR TITLE
resolved conflicting class names that existed in src and test

### DIFF
--- a/myriad-scheduler/src/test/java/org/apache/myriad/MesosTestModule.java
+++ b/myriad-scheduler/src/test/java/org/apache/myriad/MesosTestModule.java
@@ -37,8 +37,8 @@ import com.google.inject.Singleton;
 /**
  * Guice Module for Mesos objects.
  */
-public class MesosModule extends AbstractModule {
-  public MesosModule() {
+public class MesosTestModule extends AbstractModule {
+  public MesosTestModule() {
   }
 
   @Override


### PR DESCRIPTION
MesosModule.java exisited in both /src and /test, which could cause a conflict. I renamed the test version to MesosTestModule.java  Turns out nothing is using it though.