### PR TITLE
MYRIAD-164 Remove Myriad state after framework shutdown

### DIFF
--- a/myriad-scheduler/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/MyriadFileSystemRMStateStore.java
+++ b/myriad-scheduler/src/main/java/org/apache/hadoop/yarn/server/resourcemanager/recovery/MyriadFileSystemRMStateStore.java
@@ -97,4 +97,15 @@ public class MyriadFileSystemRMStateStore extends FileSystemRMStateStore impleme
       LOGGER.error("State information for Myriad could not be stored at: " + myriadStatePath, e);
     }
   }
+
+  @Override
+  public synchronized void removeMyriadState() throws Exception {
+    if (fs.exists(myriadPathRoot)) {
+      if (!fs.delete(myriadPathRoot, true)) {
+        LOGGER.error("Failed to delete MyriadStateStore path " + myriadPathRoot);
+        return;
+      }
+      LOGGER.info("Deleted Myriad state store path " + myriadPathRoot);
+    }
+  }
 }

--- a/myriad-scheduler/src/main/java/org/apache/myriad/MyriadModule.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/MyriadModule.java
@@ -146,7 +146,9 @@ public class MyriadModule extends AbstractModule {
     return new SchedulerState(myriadStateStore);
   }
 
-  private MyriadStateStore providesMyriadStateStore() {
+  @Provides
+  @Singleton
+  MyriadStateStore providesMyriadStateStore() {
     // TODO (sdaingade) Read the implementation class from yml
     // once multiple implementations are available.
     if (rmContext.getStateStore() instanceof MyriadStateStore) {

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/MyriadOperations.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/MyriadOperations.java
@@ -259,6 +259,7 @@ public class MyriadOperations {
    * Shutdown framework means the Mesos driver is stopped taking down the executors and associated tasks
    */
   public void shutdownFramework() {
+    LOGGER.info("Received request to shutdown Myriad Framework..");
     Status driverStatus = driverManager.getDriverStatus();
 
     if (Status.DRIVER_RUNNING != driverStatus) {

--- a/myriad-scheduler/src/main/java/org/apache/myriad/state/MyriadStateStore.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/state/MyriadStateStore.java
@@ -30,4 +30,5 @@ public interface MyriadStateStore {
 
   void storeMyriadState(StoreContext storeContext) throws Exception;
 
+  void removeMyriadState() throws Exception;
 }


### PR DESCRIPTION
New Myriad framework fails to start after an earlier one is shutdown.

The Myriad state saves the framework id for the old framework.
When the new framework starts, it tries to re-registers with the old framework id.
This causes an error message similar to

I1029 12:07:08.330493 15884 sched.cpp:819] Got error 'Completed framework
attempted to re-register'
I1029 12:07:08.330507 15884 sched.cpp:1625] Asked to abort the driver
I1029 12:07:08.331507 15884 sched.cpp:861] Aborting framework
'20151029-110656-1986333194-5050-10105-0001'

We need to remove the Myriad state as part of framework shutdown.

Added a method removeMyriadState to MyriadStateStore interface and added
implementation in MyriadFileSystemRMStateStore.