### PR TITLE
MYRIAD-162

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 28 13:11:41 EDT 2015
+#Wed Jun 10 10:58:12 CDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 10 10:58:12 CDT 2015
+#Wed Oct 28 13:11:41 EDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/ServiceTaskFactoryImpl.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/ServiceTaskFactoryImpl.java
@@ -34,7 +34,6 @@ import org.apache.mesos.Protos.Resource;
 import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.Value;
-import org.apache.mesos.Protos.Value.Scalar;
 import org.apache.myriad.configuration.MyriadConfiguration;
 import org.apache.myriad.configuration.MyriadExecutorConfiguration;
 import org.apache.myriad.configuration.ServiceConfiguration;
@@ -125,14 +124,11 @@ public class ServiceTaskFactoryImpl implements TaskFactory {
 
     LOGGER.info("Command line for service: {} is: {}", nodeTask.getTaskPrefix(), strB.toString());
 
-    Scalar taskMemory = Scalar.newBuilder().setValue(nodeTask.getProfile().getMemory()).build();
-    Scalar taskCpus = Scalar.newBuilder().setValue(nodeTask.getProfile().getCpus()).build();
-
     TaskInfo.Builder taskBuilder = TaskInfo.newBuilder();
 
-    taskBuilder.setName(nodeTask.getTaskPrefix()).setTaskId(taskId).setSlaveId(offer.getSlaveId()).addResources(
-        Resource.newBuilder().setName("cpus").setType(Value.Type.SCALAR).setScalar(taskCpus).build()).addResources(
-        Resource.newBuilder().setName("mem").setType(Value.Type.SCALAR).setScalar(taskMemory).build());
+    taskBuilder.setName(nodeTask.getTaskPrefix()).setTaskId(taskId).setSlaveId(offer.getSlaveId())
+        .addAllResources(taskUtils.getScalarResource(offer, "cpus", nodeTask.getProfile().getCpus(), 0.0))
+        .addAllResources(taskUtils.getScalarResource(offer, "mem", nodeTask.getProfile().getMemory(), 0.0));
 
     if (additionalPortsNumbers != null && !additionalPortsNumbers.isEmpty()) {
       // set ports
@@ -216,7 +212,7 @@ public class ServiceTaskFactoryImpl implements TaskFactory {
     }
     final List<Long> returnedPorts = new ArrayList<>();
     for (Resource resource : offer.getResourcesList()) {
-      if (resource.getName().equals("ports")) {
+      if (resource.getName().equals("ports") && (!resource.hasRole() || resource.getRole().equals("*"))) {
         Iterator<Value.Range> itr = resource.getRanges().getRangeList().iterator();
         while (itr.hasNext()) {
           Value.Range range = itr.next();

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/TaskFactory.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/TaskFactory.java
@@ -37,7 +37,6 @@ import org.apache.mesos.Protos.TaskID;
 import org.apache.mesos.Protos.TaskInfo;
 import org.apache.mesos.Protos.Value;
 import org.apache.mesos.Protos.Value.Range;
-import org.apache.mesos.Protos.Value.Scalar;
 import org.apache.myriad.configuration.MyriadConfiguration;
 import org.apache.myriad.configuration.MyriadExecutorConfiguration;
 import org.apache.myriad.state.NodeTask;
@@ -90,7 +89,7 @@ public interface TaskFactory {
     @VisibleForTesting
     protected static HashSet<Long> getNMPorts(Resource resource) {
       HashSet<Long> ports = new HashSet<>();
-      if (resource.getName().equals("ports")){
+      if (resource.getName().equals("ports")) {
         /*
         ranges.getRangeList() returns a list of ranges, each range specifies a begin and end only.
         so must loop though each range until we get all ports needed.  We exit each loop as soon as all
@@ -122,7 +121,7 @@ public interface TaskFactory {
     protected static NMPorts getPorts(Offer offer) {
       HashSet<Long> ports = new HashSet<>();
       for (Resource resource : offer.getResourcesList()) {
-        if (resource.getName().equals("ports")) {
+        if (resource.getName().equals("ports") && (!resource.hasRole() || resource.getRole().equals("*"))) {
           ports = getNMPorts(resource);
           break;
         }
@@ -179,8 +178,8 @@ public interface TaskFactory {
       LOGGER.debug(ports.toString());
 
       ServiceResourceProfile serviceProfile = nodeTask.getProfile();
-      Scalar taskMemory = Scalar.newBuilder().setValue(serviceProfile.getAggregateMemory()).build();
-      Scalar taskCpus = Scalar.newBuilder().setValue(serviceProfile.getAggregateCpu()).build();
+      Double taskMemory = serviceProfile.getAggregateMemory();
+      Double taskCpus = serviceProfile.getAggregateCpu();
 
       CommandInfo commandInfo = getCommandInfo(serviceProfile, ports);
       ExecutorInfo executorInfo = getExecutorInfoForSlave(frameworkId, offer, commandInfo);
@@ -188,39 +187,27 @@ public interface TaskFactory {
       TaskInfo.Builder taskBuilder = TaskInfo.newBuilder().setName("task-" + taskId.getValue()).setTaskId(taskId).setSlaveId(
           offer.getSlaveId());
 
-      return taskBuilder.addResources(Resource.newBuilder().setName("cpus").setType(Value.Type.SCALAR).setScalar(taskCpus).build())
-          .addResources(Resource.newBuilder().setName("mem").setType(Value.Type.SCALAR).setScalar(taskMemory).build())
-          .addResources(Resource.newBuilder().setName("ports").setType(Value.Type.RANGES).setRanges(
-              Value.Ranges.newBuilder().addRange(Value.Range.newBuilder()
-                  .setBegin(ports.getRpcPort())
-                  .setEnd(ports.getRpcPort())
-                  .build()).addRange(Value.Range.newBuilder()
-                  .setBegin(ports.getLocalizerPort())
-                  .setEnd(ports.getLocalizerPort())
-                  .build()).addRange(Value.Range.newBuilder()
-                  .setBegin(ports.getWebAppHttpPort())
-                  .setEnd(ports.getWebAppHttpPort())
-                  .build()).addRange(Value.Range.newBuilder()
-                  .setBegin(ports.getShufflePort())
-                  .setEnd(ports.getShufflePort())
-                  .build())))
+      return taskBuilder
+          .addAllResources(taskUtils.getScalarResource(offer, "cpus", taskCpus, taskUtils.getExecutorCpus()))
+          .addAllResources(taskUtils.getScalarResource(offer, "mem", taskMemory, taskUtils.getExecutorMemory()))
+          .addResources(Resource.newBuilder().setName("ports").setType(Value.Type.RANGES).setRanges(Value.Ranges.newBuilder()
+              .addRange(Range.newBuilder().setBegin(ports.getRpcPort()).setEnd(ports.getRpcPort()).build())
+              .addRange(Range.newBuilder().setBegin(ports.getLocalizerPort()).setEnd(ports.getLocalizerPort()).build())
+              .addRange(Range.newBuilder().setBegin(ports.getWebAppHttpPort()).setEnd(ports.getWebAppHttpPort()).build())
+              .addRange(Range.newBuilder().setBegin(ports.getShufflePort()).setEnd(ports.getShufflePort()).build())))
           .setExecutor(executorInfo)
           .build();
     }
 
     @Override
     public ExecutorInfo getExecutorInfoForSlave(FrameworkID frameworkId, Offer offer, CommandInfo commandInfo) {
-      Scalar executorMemory = Scalar.newBuilder().setValue(taskUtils.getExecutorMemory()).build();
-      Scalar executorCpus = Scalar.newBuilder().setValue(taskUtils.getExecutorCpus()).build();
-
-      ExecutorID executorId = ExecutorID.newBuilder().setValue(EXECUTOR_PREFIX + frameworkId.getValue() +
-                                                               offer.getId().getValue() + offer.getSlaveId().getValue()).build();
-      return ExecutorInfo.newBuilder().setCommand(commandInfo).setName(EXECUTOR_NAME).addResources(Resource.newBuilder().setName(
-          "cpus").setType(Value.Type.SCALAR).setScalar(executorCpus).build()).addResources(Resource.newBuilder()
-          .setName("mem")
-          .setType(Value.Type.SCALAR)
-          .setScalar(executorMemory)
-          .build()).setExecutorId(executorId).build();
+      ExecutorID executorId = ExecutorID.newBuilder()
+          .setValue(EXECUTOR_PREFIX + frameworkId.getValue() + offer.getId().getValue() + offer.getSlaveId().getValue())
+          .build();
+      return ExecutorInfo.newBuilder().setCommand(commandInfo).setName(EXECUTOR_NAME).setExecutorId(executorId)
+          .addAllResources(taskUtils.getScalarResource(offer, "cpus", taskUtils.getExecutorCpus(), 0.0))
+          .addAllResources(taskUtils.getScalarResource(offer, "mem", taskUtils.getExecutorMemory(), 0.0))
+          .build();
     }
   }
 

--- a/myriad-scheduler/src/test/java/org/apache/myriad/scheduler/fgs/YarnNodeCapacityManagerSpec.groovy
+++ b/myriad-scheduler/src/test/java/org/apache/myriad/scheduler/fgs/YarnNodeCapacityManagerSpec.groovy
@@ -22,7 +22,9 @@ import org.apache.hadoop.yarn.api.records.ContainerState
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeResourceUpdateSchedulerEvent
 import org.apache.hadoop.yarn.util.resource.Resources
 import org.apache.mesos.Protos
+import org.apache.myriad.configuration.MyriadConfiguration
 import org.apache.myriad.configuration.NodeManagerConfiguration
+import org.apache.myriad.scheduler.TaskUtils
 import org.apache.myriad.scheduler.yarn.interceptor.InterceptorRegistry
 import org.apache.myriad.state.NodeTask
 import org.apache.myriad.state.SchedulerState
@@ -128,8 +130,13 @@ class YarnNodeCapacityManagerSpec extends FGSTestBaseSpec {
         def state = Mock(SchedulerState) {
             getNodeTask(_, NodeManagerConfiguration.NM_TASK_PREFIX) >> nodeTask
         }
+        def cfg = Mock(MyriadConfiguration) {
+            getFrameworkRole() >> "some_role"
+        }
+        print(cfg.getFrameworkRole())
+        def taskUtils = new TaskUtils(cfg)
         return new YarnNodeCapacityManager(registry, yarnScheduler, rmContext,
-                myriadDriver, offerLifecycleManager, nodeStore, state)
+                myriadDriver, offerLifecycleManager, nodeStore, state, taskUtils)
 
     }
 }


### PR DESCRIPTION
This corrects how offers are handled when using the framework role parameter.  Prior to this fix if Myriad received an offer with resource from the default role and it's declared role it incorrectly declared all cpu and memory as used by the default role.  This let to TASK_LOST errors, which the logs stated were a result of insufficient resources.

Tested on a cluster with a variety of different agent configurations, which required the use of cpus and mem resources from both the default ("*") and frameworkRole ("roleA").  Verified correct behavior for both coarse and fine grained scaling.

NB: This PR does not fix the issue for the ports resource and explicitly forces Myriad the use the default ("*") role for ports.  I believe there is potential to use reserved port for a role to help Myriad, but that would require more changes and be more of a improvement than bug-fix, hence is to be future work.

I would like to squash commits and clean up formatting before merge, but I thought I'd submit the PR now to solicit comments.