### PR TITLE
MYRIAD-170 Myriad initialization fails with "parameter 5 of org.apach…

### DIFF
--- a/myriad-scheduler/src/main/java/org/apache/myriad/MyriadModule.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/MyriadModule.java
@@ -146,9 +146,7 @@ public class MyriadModule extends AbstractModule {
     return new SchedulerState(myriadStateStore);
   }
 
-  @Provides
-  @Singleton
-  MyriadStateStore providesMyriadStateStore() {
+  private MyriadStateStore providesMyriadStateStore() {
     // TODO (sdaingade) Read the implementation class from yml
     // once multiple implementations are available.
     if (rmContext.getStateStore() instanceof MyriadStateStore) {


### PR DESCRIPTION
…e.myriad.scheduler.MyriadOperations.<init>() is not @Nullable

Myriad State store is no longer passed using Guice
We now get state store from RMContext.

Tried using HA disabled in yarn and myriad. Was able to run CGS and FGS NM's
Tried using HA enabled in yarn and myriad. Was able to run CGS and FGS NM's