### PR TITLE
Myriad 172

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 28 13:11:41 EDT 2015
+#Wed Jun 10 10:58:12 CDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 10 10:58:12 CDT 2015
+#Wed Oct 28 13:11:41 EDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/TaskUtils.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/TaskUtils.java
@@ -238,9 +238,10 @@ public class TaskUtils {
       }
     }
     //Assume enough resources are present in default value, if not we shouldn't of gotten to this function.
-    if (value - (resourceDoubleValue - used) > 0) {
+    //Use Math.max in case used>resourceDoubleValue
+    if (value - Math.max((resourceDoubleValue - used), 0) > 0) {
       resources.add(Protos.Resource.newBuilder().setName(name).setType(Protos.Value.Type.SCALAR)
-          .setScalar(Protos.Value.Scalar.newBuilder().setValue(value - (resourceDoubleValue - used)).build())
+          .setScalar(Protos.Value.Scalar.newBuilder().setValue(value - Math.max((resourceDoubleValue - used), 0)).build())
           .build()); //no role assumes default
     }
     return resources;


### PR DESCRIPTION
This corrects the offer handling in `TaskUtils.getScalarResource`.  Previously, the case were the amount of resources of the frameworkRole was less than the amount used was overlooked.  This caused a positive number to be added to the amount still needed, resulting in more than the desired resource being requested.  Using `Math.max(resourceDoubleValue-used,0)` corrects this behaviour.

Tested and confirmed correct resources were requested.
