### PR TITLE
Prepended FrameworkName to the task-name

### DIFF
--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/TaskFactory.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/TaskFactory.java
@@ -184,7 +184,7 @@ public interface TaskFactory {
       CommandInfo commandInfo = getCommandInfo(serviceProfile, ports);
       ExecutorInfo executorInfo = getExecutorInfoForSlave(frameworkId, offer, commandInfo);
 
-      TaskInfo.Builder taskBuilder = TaskInfo.newBuilder().setName(cfg.getFrameworkName() + "-task-" + taskId.getValue()).setTaskId(taskId).setSlaveId(
+      TaskInfo.Builder taskBuilder = TaskInfo.newBuilder().setName(cfg.getFrameworkName() + "-" + taskId.getValue()).setTaskId(taskId).setSlaveId(
           offer.getSlaveId());
 
       return taskBuilder

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/TaskFactory.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/TaskFactory.java
@@ -184,7 +184,7 @@ public interface TaskFactory {
       CommandInfo commandInfo = getCommandInfo(serviceProfile, ports);
       ExecutorInfo executorInfo = getExecutorInfoForSlave(frameworkId, offer, commandInfo);
 
-      TaskInfo.Builder taskBuilder = TaskInfo.newBuilder().setName("task-" + taskId.getValue()).setTaskId(taskId).setSlaveId(
+      TaskInfo.Builder taskBuilder = TaskInfo.newBuilder().setName(cfg.getFrameworkName() + "-task-" + taskId.getValue()).setTaskId(taskId).setSlaveId(
           offer.getSlaveId());
 
       return taskBuilder


### PR DESCRIPTION
Prepends the frameworkname to the task-name in mesos. This will make things easier for organizations running multiple Myriad clusters at the same time. 

https://issues.apache.org/jira/browse/MYRIAD-141