### PR TITLE
Added 'incubating' to first mentions of Myriad on website.

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,4 +1,4 @@
-# Apache Myriad Website
+# Apache Myriad (incubating) Website
 
 This is the source for the Apache Myriad [site](http://myriad.incubator.apache.org). The site is a [Jekyll](http://jekyll.rb) blog with [Material Design Lite] (http://www.getmdl.io/) for the look and feel.
 

--- a/website/_config.yml
+++ b/website/_config.yml
@@ -18,7 +18,7 @@
 #####
 
 # Site settings
-title: Apache Myriad
+title: Apache Myriad (incubating)
 email: dev@myriad.incubator.apache.org
 description: > # this means to ignore newlines until "baseurl:"
     Deploy Apache YARN Applications Using Apache Mesos

--- a/website/documentation/index.md
+++ b/website/documentation/index.md
@@ -3,7 +3,7 @@ layout: big_card_for_md
 title: Documentation
 permalink: /docs/
 ---
-#### Myriad
+#### Apache Myriad (incubating)
 
 Myriad maintains a wiki [here.](https://cwiki.apache.org/myriad) Create an account and post to the dev list to help keep it up to date.
 

--- a/website/index.html
+++ b/website/index.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Myriad
+title: Apache Myriad (incubating)
 ---
 {% comment %}
 <!--


### PR DESCRIPTION
Added 'incubating' status to first mentions of Apache Myriad on the website,
per Apache branding guidelines.