### PR TITLE
MYRIAD-175 Change Destroy myriad REST api method from 'GET' to 'POST/PUT'

### DIFF
--- a/myriad-scheduler/src/main/java/org/apache/myriad/api/ControllerResource.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/api/ControllerResource.java
@@ -49,7 +49,7 @@ public class ControllerResource {
    * @return a successful response.
    */
   @Timed
-  @GET
+  @POST
   @Path("/shutdown/framework")
   @Produces(MediaType.APPLICATION_JSON)
   public Response shutdownFramework() {


### PR DESCRIPTION
I should mention that I decided to go with POST, as that is the same command used for the /shutdown endpoint within mesos, as you can see in the file [here](https://github.com/apache/mesos/blob/master/src/master/http.cpp).