### PR TITLE
Addresses Myriad 188 - NodeManager switch to UNHEALTHY causes NPE on …

### DIFF
--- a/myriad-scheduler/src/test/java/org/apache/myriad/scheduler/fgs/FGSTestBaseSpec.groovy
+++ b/myriad-scheduler/src/test/java/org/apache/myriad/scheduler/fgs/FGSTestBaseSpec.groovy
@@ -33,6 +33,7 @@ import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.AbstractYarnScheduler
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerApplicationAttempt
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.SchedulerNode
+import org.apache.hadoop.yarn.server.resourcemanager.scheduler.fair.FSSchedulerNode
 import org.apache.hadoop.yarn.util.resource.Resources
 import org.apache.mesos.Protos
 import org.apache.mesos.SchedulerDriver
@@ -65,6 +66,7 @@ class FGSTestBaseSpec extends Specification {
 
     def rmNodes = new ConcurrentHashMap<NodeId, RMNode>()
 
+
     RMNode getRMNode(int cpu, int mem, String host, Protos.SlaveID slaveId) {
         RMNode rmNode = MockNodes.newNodeInfo(0, Resources.createResource(mem, cpu), 0, host)
         if (rmNodes[rmNode.getNodeID()]) {
@@ -80,17 +82,16 @@ class FGSTestBaseSpec extends Specification {
 
     SchedulerNode getSchedulerNode(RMNode rmNode) {
         SchedulerNode schedulerNode = new SchedulerNode(rmNode, false) {
-
             @Override
             void reserveResource(SchedulerApplicationAttempt attempt, Priority priority, RMContainer container) {
             }
-
             @Override
             void unreserveResource(SchedulerApplicationAttempt attempt) {
             }
         }
         return schedulerNode
     }
+
 
     /******************* RMContext Related ****************/
 
@@ -143,6 +144,8 @@ class FGSTestBaseSpec extends Specification {
 
     AbstractYarnScheduler yarnScheduler = Mock(AbstractYarnScheduler) {
         getRMContainer(_ as ContainerId) >> { ContainerId cid -> fgsContainers.get(cid).rmContainer }
+        getSchedulerNode(_ as NodeId) >> { NodeId nodeId -> getSchedulerNode(rmNodes.get(nodeId)) }
+        updateNodeResource(_ as RMNode, _ as ResourceOption) >> { }
     }
 
     FGSContainer getFGSContainer(RMNode node, int cid, int cpu, int mem, ContainerState state) {

--- a/myriad-scheduler/src/test/java/org/apache/myriad/scheduler/fgs/YarnNodeCapacityManagerSpec.groovy
+++ b/myriad-scheduler/src/test/java/org/apache/myriad/scheduler/fgs/YarnNodeCapacityManagerSpec.groovy
@@ -19,6 +19,8 @@
 package org.apache.myriad.scheduler.fgs
 
 import org.apache.hadoop.yarn.api.records.ContainerState
+import org.apache.hadoop.yarn.api.records.ResourceOption
+import org.apache.hadoop.yarn.server.resourcemanager.rmnode.RMNode
 import org.apache.hadoop.yarn.server.resourcemanager.scheduler.event.NodeResourceUpdateSchedulerEvent
 import org.apache.hadoop.yarn.util.resource.Resources
 import org.apache.mesos.Protos
@@ -115,7 +117,7 @@ class YarnNodeCapacityManagerSpec extends FGSTestBaseSpec {
         then:
         zeroNM.getTotalCapability().getMemory() == 2048
         zeroNM.getTotalCapability().getVirtualCores() == 2
-        1 * rmContext.getDispatcher().getEventHandler().handle(_ as NodeResourceUpdateSchedulerEvent)
+        1 * yarnScheduler.updateNodeResource( _ as RMNode, _ as ResourceOption)
     }
 
     YarnNodeCapacityManager getYarnNodeCapacityManager() {
@@ -137,6 +139,5 @@ class YarnNodeCapacityManagerSpec extends FGSTestBaseSpec {
         def taskUtils = new TaskUtils(cfg)
         return new YarnNodeCapacityManager(registry, yarnScheduler, rmContext,
                 myriadDriver, offerLifecycleManager, nodeStore, state, taskUtils)
-
     }
 }


### PR DESCRIPTION
…ResourceManager. @sdaingade I believe this also addresses Myriad-156, which was assigned to you.  @kensipe can you look over the unit test mods?  I don't really know spock or groovy.  I'd like to add a test case for if the node doesn't exist in the yarnscheduler, though that may be difficult with mocks.