### PR TITLE
Continuation of Myriad 171

### DIFF
--- a/myriad-scheduler/src/test/java/org/apache/myriad/scheduler/fgs/YarnNodeCapacityManagerSpec.groovy
+++ b/myriad-scheduler/src/test/java/org/apache/myriad/scheduler/fgs/YarnNodeCapacityManagerSpec.groovy
@@ -117,7 +117,7 @@ class YarnNodeCapacityManagerSpec extends FGSTestBaseSpec {
         then:
         zeroNM.getTotalCapability().getMemory() == 2048
         zeroNM.getTotalCapability().getVirtualCores() == 2
-        1 * yarnScheduler.updateNodeResource( _ as RMNode, _ as ResourceOption)
+        1 * rmContext.getDispatcher().getEventHandler().handle(_ as NodeResourceUpdateSchedulerEvent)
     }
 
     YarnNodeCapacityManager getYarnNodeCapacityManager() {


### PR DESCRIPTION
Started to work towards public methods incrementResources and decrementResources, as it's easier to reason about purely additive functions in multithreaded environments. Fixed minor bugs in previous Myriad-171 patch, placed the guard for Node Managers having negative resources in setNodeCapacity and reverted back any from calling yarnScheduler.updateNode directly. Very well tested.