### PR TITLE
Minor few bug fixes, and a trivial UI fix for shutdown Myriad.

### DIFF
--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/NMExecutorCLGenImpl.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/NMExecutorCLGenImpl.java
@@ -110,7 +110,6 @@ public class NMExecutorCLGenImpl implements ExecutorCommandLineGenerator {
   protected void appendCgroupsCmds(StringBuilder cmdLine) {
     if (cfg.getFrameworkSuperUser().isPresent()) {
       cmdLine.append(" export TASK_DIR=`basename $PWD`&&");
-      appendSudo(cmdLine);
       //The container executor script expects mount-path to exist and owned by the yarn user
       //See: https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/NodeManagerCgroups.html
       //If YARN ever moves to cgroup/mem it will be necessary to add a mem version.

--- a/myriad-scheduler/src/main/resources/webapp/js/components/FlexDownComponent.js
+++ b/myriad-scheduler/src/main/resources/webapp/js/components/FlexDownComponent.js
@@ -114,7 +114,7 @@ var FlexDownComponent = React.createClass({
    }
    for( var ii = 0; ii < keys.length; ii++) {
        var key = keys[ii];
-       var txt = key;
+       var txt = key + '\t' + JSON.stringify(this.props.profiles[key]);
        options.push( <option key={key} value={key}>{txt}</option> );
    }
 

--- a/myriad-scheduler/src/main/resources/webapp/js/components/ShutdownFrameworkComponent.js
+++ b/myriad-scheduler/src/main/resources/webapp/js/components/ShutdownFrameworkComponent.js
@@ -81,7 +81,7 @@ var ShutdownFrameworkComponent = React.createClass({
 	},
   	onRequestShutdown: function() {
     		console.log( "shutting down Myriad .... ");
-    		request.get('/api/framework/shutdown/framework')
+    		request.post('/api/framework/shutdown/framework')
     			.set('Content-Type', 'application/json')
     			.end(function(err, res){
            			console.log("Result from /api/framework/shutdown/framework");


### PR DESCRIPTION
Couple of minor bug fixes for 0.2 RC:
1. UI frameworkShutdown is broken because of  PR#58.
2. Additional 'sudo' from cgroup cmdline.
3. Adding profile info to flexdown UI (keep same with flexup).