### PR TITLE
Fixed regression in configuration from merge of PR #75

### DIFF
--- a/myriad-scheduler/src/main/java/org/apache/myriad/configuration/MyriadConfiguration.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/configuration/MyriadConfiguration.java
@@ -21,7 +21,6 @@ package org.apache.myriad.configuration;
 import java.util.Collections;
 import java.util.Map;
 
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -134,11 +133,9 @@ public class MyriadConfiguration {
   private String frameworkRole;
 
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializer.OptionalSerializerString.class)
   private String frameworkUser;
 
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializer.OptionalSerializerString.class)
   private String frameworkSuperUser;
 
   @JsonProperty

--- a/myriad-scheduler/src/main/java/org/apache/myriad/configuration/MyriadExecutorConfiguration.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/configuration/MyriadExecutorConfiguration.java
@@ -20,10 +20,7 @@ package org.apache.myriad.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
-import org.apache.myriad.configuration.OptionalSerializer.OptionalSerializerDouble;
-import org.apache.myriad.configuration.OptionalSerializer.OptionalSerializerString;
 import org.apache.myriad.executor.MyriadExecutorDefaults;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**
@@ -34,7 +31,6 @@ public class MyriadExecutorConfiguration {
    * Translates to -Xmx for the NodeManager JVM.
    */
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializerDouble.class)
   private Double jvmMaxMemoryMB;
 
   @JsonProperty
@@ -42,11 +38,9 @@ public class MyriadExecutorConfiguration {
   private String path;
 
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializerString.class)
   private String nodeManagerUri;
 
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializerString.class)
   private String configUri;
 
   /**
@@ -56,7 +50,6 @@ public class MyriadExecutorConfiguration {
    * inside sandbox.
    */
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializerString.class)
   private String jvmUri;
 
   private Double generateMaxMemory() {

--- a/myriad-scheduler/src/main/java/org/apache/myriad/configuration/NodeManagerConfiguration.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/configuration/NodeManagerConfiguration.java
@@ -20,10 +20,6 @@ package org.apache.myriad.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
-import org.apache.myriad.configuration.OptionalSerializer.OptionalSerializerBoolean;
-import org.apache.myriad.configuration.OptionalSerializer.OptionalSerializerDouble;
-import org.apache.myriad.configuration.OptionalSerializer.OptionalSerializerString;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 
 /**
  * YARN NodeManager Configuration
@@ -58,7 +54,6 @@ public class NodeManagerConfiguration {
    * Translates to -Xmx for the NodeManager JVM.
    */
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializerDouble.class)
   private Double jvmMaxMemoryMB;
 
   /**
@@ -66,21 +61,18 @@ public class NodeManagerConfiguration {
    * for NodeManager auxiliary services.
    */
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializerDouble.class)
   private Double cpus;
 
   /**
    * Translates to JAVA_OPTS for the NodeManager JVM.
    */
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializerString.class)
   private String jvmOpts;
   
   /**
    * Determines if cgroups are enabled for the NodeManager
    */
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializerBoolean.class)
   private Boolean cgroups;
 
   private Double generateNodeManagerMemory() {

--- a/myriad-scheduler/src/main/java/org/apache/myriad/configuration/ServiceConfiguration.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/configuration/ServiceConfiguration.java
@@ -20,7 +20,6 @@ package org.apache.myriad.configuration;
 
 import java.util.Map;
 
-import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -51,25 +50,21 @@ public class ServiceConfiguration {
    * Translates to -Xmx for the Mesos executor JVM.
    */
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializer.OptionalSerializerDouble.class)
   protected Double jvmMaxMemoryMB;
 
   /**
    * Amount of CPU share given to Mesos executor JVM.
    */
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializer.OptionalSerializerDouble.class)
   protected Double cpus;
 
   /**
    * Translates to JVM opts for the Mesos executor JVM.
    */
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializer.OptionalSerializerString.class)
   protected String jvmOpts;
 
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializer.OptionalSerializerMap.class)
   protected Map<String, Long> ports;
 
   /**
@@ -78,7 +73,6 @@ public class ServiceConfiguration {
    * we can use this one to have a specific implementation
    */
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializer.OptionalSerializerString.class)
   protected String taskFactoryImplName;
 
   @JsonProperty
@@ -89,11 +83,9 @@ public class ServiceConfiguration {
   protected String taskName;
 
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializer.OptionalSerializerInt.class)
   protected Integer maxInstances;
 
   @JsonProperty
-  @JsonSerialize(using = OptionalSerializer.OptionalSerializerString.class)
   protected String command;
 
   @JsonProperty


### PR DESCRIPTION
When the last the last PR was merged the @JsonSerialize anotations were not being removed on objects that are no longer Optionals.  This caused the config to not be serialized properly and this broke REST interface /api/config and the corresponding issues with the WebUI.

@hokiegeek2 I think this is good, but you may want to take a quick look.