### PR TITLE
MYRIAD-247 Fail to fetch yarnConfiguration from Resourcemanager

### DIFF
--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/ExecutorCommandLineGenerator.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/ExecutorCommandLineGenerator.java
@@ -77,7 +77,7 @@ public abstract class ExecutorCommandLineGenerator {
       //config file to yarnConfiguration, It's an xml file with the parameters of yarn-site.xml, core-site.xml and hdfs.xml.
       if (!myriadExecutorConfiguration.getConfigUri().isPresent()) {
         appendSudo(cmdLine);
-        cmdLine.append(" cp yarnConfiguration ");
+        cmdLine.append(" cp conf ");
         cmdLine.append(myriadConfiguration.getYarnEnvironment().get("YARN_HOME"));
         cmdLine.append("/etc/hadoop/yarn-site.xml && ");
       }
@@ -111,13 +111,13 @@ public abstract class ExecutorCommandLineGenerator {
       if (StringUtils.isEmpty(address)) {
         address = yarnConfiguration.get(TaskFactory.YARN_RESOURCEMANAGER_HOSTNAME) + ":8090";
       }
-      return "https://" + address + "/yarnConfiguration";
+      return "https://" + address + "/conf";
     } else {
       address = yarnConfiguration.get(TaskFactory.YARN_RESOURCEMANAGER_WEBAPP_ADDRESS);
       if (StringUtils.isEmpty(address)) {
         address = yarnConfiguration.get(TaskFactory.YARN_RESOURCEMANAGER_HOSTNAME) + ":8088";
       }
-      return "http://" + address + "/yarnConfiguration";
+      return "http://" + address + "/conf";
     }
   }
 

--- a/myriad-scheduler/src/test/java/org/apache/myriad/scheduler/TestServiceCommandLine.java
+++ b/myriad-scheduler/src/test/java/org/apache/myriad/scheduler/TestServiceCommandLine.java
@@ -47,10 +47,10 @@ public class TestServiceCommandLine extends BaseConfigurableTest {
       + System.lineSeparator() + "%s";
   protected static final String CMD_FORMAT = "echo \"%1$s\" && %1$s";
   static String toJHSCompare =
-      " sudo tar -zxpf hadoop-2.7.0.tar.gz &&  sudo  cp yarnConfiguration /usr/local/hadoop/etc/hadoop/yarn-site.xml &&  " +
+      " sudo tar -zxpf hadoop-2.7.0.tar.gz &&  sudo  cp conf /usr/local/hadoop/etc/hadoop/yarn-site.xml &&  " +
           "sudo -E -u hduser -H  bin/mapred historyserver";
   static String toCompare =
-      " sudo tar -zxpf hadoop-2.7.0.tar.gz &&  sudo  cp yarnConfiguration /usr/local/hadoop/etc/hadoop/yarn-site.xml &&  " +
+      " sudo tar -zxpf hadoop-2.7.0.tar.gz &&  sudo  cp conf /usr/local/hadoop/etc/hadoop/yarn-site.xml &&  " +
           "sudo -E -u hduser -H  $YARN_HOME/bin/yarn nodemanager";
 
   @Test


### PR DESCRIPTION
We can fetch configuration file from `http://rm-host:8088/conf` but not  `http://rm-host:8088/yarnConfiguration`