### PR TITLE
MYRIAD-249 Should set NodeManager vcores more flexibly

### DIFF
--- a/myriad-scheduler/src/main/java/org/apache/myriad/configuration/NodeManagerConfiguration.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/configuration/NodeManagerConfiguration.java
@@ -62,6 +62,11 @@ public class NodeManagerConfiguration {
    * Default max CPU cores for NodeManager JVM
    */
   public static final double DEFAULT_NM_MAX_CPUS = 24;
+
+  /**
+   * Default vcore multiplier for NodeManager
+   */
+  public static final double DEFAULT_VCORE_MULTIPLIER = 1;
   
   /**
    * Translates to -Xmx for the NodeManager JVM.
@@ -94,6 +99,9 @@ public class NodeManagerConfiguration {
   @JsonProperty
   private Double maxCpus;
   
+  @JsonProperty
+  private Double vcoreMultiplier;
+
   private Double generateNodeManagerMemory() {
     return (NodeManagerConfiguration.DEFAULT_JVM_MAX_MEMORY_MB) * (1 + NodeManagerConfiguration.JVM_OVERHEAD);
   }
@@ -128,5 +136,9 @@ public class NodeManagerConfiguration {
   
   public Double getMaxCpus() {
     return Optional.fromNullable(maxCpus).or(DEFAULT_NM_MAX_CPUS);
+  }
+
+  public Double getVcoreMultiplier() {
+    return Optional.fromNullable(vcoreMultiplier).or(DEFAULT_VCORE_MULTIPLIER);
   }
 }

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/NMExecutorCommandLineGenerator.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/NMExecutorCommandLineGenerator.java
@@ -101,7 +101,9 @@ public class NMExecutorCommandLineGenerator extends ExecutorCommandLineGenerator
       addJavaOpt(yarnOpts, KEY_YARN_HOME, yarnEnv.get("YARN_HOME"));
     }
 
-    addJavaOpt(yarnOpts, KEY_NM_RESOURCE_CPU_VCORES, Integer.toString(profile.getCpus().intValue()));
+    int vcores = (int) (myriadConfiguration.getNodeManagerConfiguration()
+        .getVcoreMultiplier() * profile.getCpus().intValue());
+    addJavaOpt(yarnOpts, KEY_NM_RESOURCE_CPU_VCORES, Integer.toString(vcores));
     addJavaOpt(yarnOpts, KEY_NM_RESOURCE_MEM_MB, Integer.toString(profile.getMemory().intValue()));
     Map<String, Long> portsMap = profile.getPorts();
     Preconditions.checkState(portsMap.size() == ports.size());


### PR DESCRIPTION
add field vcoreMultplier in NodeManagerConfiguration. Then vcore of NodeManager would be cpu in profile muliply vcoreMultifier.
eg:
```
profiles:
  zero:  # NMs launched with this profile dynamically obtain cpu/mem from Mesos
    cpu: 0
    mem: 0
  small:
    cpu: 2
    mem: 2048
  medium:
    cpu: 4
    mem: 4096
  large:
    cpu: 10
    mem: 12288
nmInstances: # NMs to start with. Requires at least 1 NM with a non-zero profile.
  medium: 1 # <profile_name : instances>
rebalancer: false
haEnabled: false
nodemanager:
  jvmMaxMemoryMB: 1024
  cpus: 0.2
  cgroups: false
  vcoreMultiplier: 2
```
Once flex up medium-size nodemanager, it consumes 4.4 CPUs on mesos, and launched nodemanager has 8 vcores.