### PR TITLE
MYRIAD-250 Should shutdown mesos framework when stop resourcemanager

### DIFF
--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/MyriadCapacityScheduler.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/MyriadCapacityScheduler.java
@@ -77,6 +77,12 @@ public class MyriadCapacityScheduler extends CapacityScheduler {
   }
 
   @Override
+  public synchronized void serviceStop() throws Exception {
+    this.yarnSchedulerInterceptor.cleanup();
+    super.serviceStop();
+  }
+
+  @Override
   public synchronized void handle(SchedulerEvent event) {
     this.yarnSchedulerInterceptor.beforeSchedulerEventHandled(event);
     super.handle(event);

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/MyriadFairScheduler.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/MyriadFairScheduler.java
@@ -97,6 +97,12 @@ public class MyriadFairScheduler extends FairScheduler {
   }
 
   @Override
+  public synchronized void serviceStop() throws Exception {
+    this.yarnSchedulerInterceptor.cleanup();
+    super.serviceStop();
+  }
+
+  @Override
   public synchronized void handle(SchedulerEvent event) {
     this.yarnSchedulerInterceptor.beforeSchedulerEventHandled(event);
     super.handle(event);

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/MyriadFifoScheduler.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/MyriadFifoScheduler.java
@@ -77,6 +77,12 @@ public class MyriadFifoScheduler extends FifoScheduler {
   }
 
   @Override
+  public synchronized void serviceStop() throws Exception {
+    this.yarnSchedulerInterceptor.cleanup();
+    super.serviceStop();
+  }
+
+  @Override
   public synchronized void handle(SchedulerEvent event) {
     this.yarnSchedulerInterceptor.beforeSchedulerEventHandled(event);
     super.handle(event);

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/interceptor/BaseInterceptor.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/interceptor/BaseInterceptor.java
@@ -66,6 +66,10 @@ public class BaseInterceptor implements YarnSchedulerInterceptor {
   }
 
   @Override
+  public void cleanup() throws IOException {
+  }
+
+  @Override
   public void beforeRMNodeEventHandled(RMNodeEvent event, RMContext context) {
 
   }

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/interceptor/CompositeInterceptor.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/interceptor/CompositeInterceptor.java
@@ -54,6 +54,7 @@ public class CompositeInterceptor implements YarnSchedulerInterceptor, Intercept
 
   private Map<Class<?>, YarnSchedulerInterceptor> interceptors = Maps.newLinkedHashMap();
   private YarnSchedulerInterceptor myriadInitInterceptor;
+  private YarnSchedulerInterceptor myriadCleanupInterceptor;
 
   /**
    * Called by Myriad{Fair,Capacity,Fifo}Scheduler classes. Creates an instance of
@@ -61,6 +62,7 @@ public class CompositeInterceptor implements YarnSchedulerInterceptor, Intercept
    */
   public CompositeInterceptor() {
     this.myriadInitInterceptor = new MyriadInitializationInterceptor(this);
+    this.myriadCleanupInterceptor = new MyriadCleanupInterceptor(this);
   }
 
   @VisibleForTesting
@@ -126,6 +128,11 @@ public class CompositeInterceptor implements YarnSchedulerInterceptor, Intercept
   @Override
   public void init(Configuration conf, AbstractYarnScheduler yarnScheduler, RMContext rmContext) throws IOException {
     myriadInitInterceptor.init(conf, yarnScheduler, rmContext);
+  }
+
+  @Override
+  public void cleanup() throws IOException {
+    myriadCleanupInterceptor.cleanup();    
   }
 
   @Override

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/interceptor/MyriadCleanupInterceptor.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/interceptor/MyriadCleanupInterceptor.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.myriad.scheduler.yarn.interceptor;
+
+import java.io.IOException;
+
+import org.apache.myriad.Main;
+import org.apache.myriad.scheduler.MyriadDriverManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Responsible for shutdown Myriad by invoking stopDriver upon the 
+ * Myriad driver {@link org.apache.myriad.Main}
+ */
+public class MyriadCleanupInterceptor extends BaseInterceptor {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MyriadCleanupInterceptor.class);
+
+  private final InterceptorRegistry registry;
+
+  public MyriadCleanupInterceptor(InterceptorRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public void cleanup() throws IOException {
+    try {
+      LOGGER.info("stopping mesosDriver..");
+      Main.getInjector().getInstance(MyriadDriverManager.class).stopDriver(false);
+      LOGGER.info("stopped mesosDriver..");
+    } catch (Exception e) {
+      // Abort shutdown RM
+      throw new RuntimeException("Failed to stop myriad", e);
+    }
+    LOGGER.info("Stopped myriad.");
+  }
+}

--- a/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/interceptor/YarnSchedulerInterceptor.java
+++ b/myriad-scheduler/src/main/java/org/apache/myriad/scheduler/yarn/interceptor/YarnSchedulerInterceptor.java
@@ -78,15 +78,24 @@ public interface YarnSchedulerInterceptor {
    */
   public void beforeCompletedContainer(RMContainer rmContainer, ContainerStatus containerStatus, RMContainerEventType event);
 
-    /**
-     * Invoked *before* {@link AbstractYarnScheduler#reinitialize(Configuration, RMContext)}
-     *
-     * @param conf
-     * @param yarnScheduler
-     * @param rmContext
-     * @throws IOException
-     */
+  /**
+   * Invoked *before*
+   * {@link AbstractYarnScheduler#reinitialize(Configuration, RMContext)}
+   *
+   * @param conf
+   * @param yarnScheduler
+   * @param rmContext
+   * @throws IOException
+   */
   public void init(Configuration conf, AbstractYarnScheduler yarnScheduler, RMContext rmContext) throws IOException;
+
+  /**
+   * Invoked *before*
+   * {@link AbstractYarnScheduler#serviceStop()}
+   *
+   * @throws IOException
+   */
+  public void cleanup() throws IOException;
 
   /**
    * Invoked *before* {@link RMNodeImpl#handle(RMNodeEvent)} only if


### PR DESCRIPTION
Added MyriadCleanupInterceptor, once scheduler(fair, fifo, capacity) is stopped, `MyriadDriverManager.stopDriver()` will be invoked to shutdown the mesos framework.
As a result, all nodemanagers launched by the resourcemanger would be killed once the RM is stopped.