### PR TITLE
Make links relative in index.html.

### DIFF
--- a/myriad-scheduler/src/main/resources/webapp/index.html
+++ b/myriad-scheduler/src/main/resources/webapp/index.html
@@ -22,13 +22,13 @@
     <meta charset="utf-8">
     <title>Myriad</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/x-icon" href="/img/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="img/favicon.ico">
     <link rel="stylesheet" href="css/bootstrap-myriad.css">
-    <link rel="stylesheet" href="/css/myriad.css">
+    <link rel="stylesheet" href="css/myriad.css">
 </head>
 <body>
     <div id="myriad"></div>
 
-    <script src="/js/myriad.js"></script>
+    <script src="js/myriad.js"></script>
 </body>
 </html>


### PR DESCRIPTION
When working with a Proxy (e.g., the DC/OS UI) we need these to be relative links.