### PR TITLE
Remove maven central repository, use only jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ tasks.withType(JavaCompile) {
 buildscript {
     repositories {
         jcenter()
-        mavenCentral()
     }
 
     dependencies {
@@ -37,7 +36,7 @@ buildscript {
 }
 
 repositories {
-    mavenCentral()
+    jcenter()
 }
 
 idea {
@@ -95,7 +94,7 @@ subprojects {
     }
 
     repositories {
-        mavenCentral()
+        jcenter()
         mavenLocal()
     }
 


### PR DESCRIPTION
jcenter is a super set on top of maven central, so having both of those repositories is redundant, and the preferred one should be jcenter.