### PR TITLE
Switching to oraclejdk8 to take care of JDK version issues with builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk7
+  - oraclejdk8 
 
 script:
   - TERM=dumb ./gradlew build


### PR DESCRIPTION
Switching to oraclejdk8 for builds, as oraclejdk7 is EOLd.

See: https://docs.travis-ci.com/user/reference/trusty/#JVM-(Clojure%2C-Groovy%2C-Java%2C-Scala)-images