### PR TITLE
MYRIAD-281 myriad-repository is pointing to wrong repository

### DIFF
--- a/vagrant/libvirt/dcos/provisioning/group_vars/all/defaults.yml
+++ b/vagrant/libvirt/dcos/provisioning/group_vars/all/defaults.yml
@@ -54,7 +54,7 @@ nfs_shared_folder: /opt/shared
 
 # Source code location for Mesos and Myriad
 myriad_cloned_folder: myriad
-myriad_repository: https://github.com/myriad-framework/myriad
+myriad_repository: https://github.com/apache/incubator-myriad
 myriad_repo_branch: master
 
 # Hadoop configrations 

--- a/vagrant/libvirt/mesos/provisioning/group_vars/all/defaults.yml
+++ b/vagrant/libvirt/mesos/provisioning/group_vars/all/defaults.yml
@@ -73,7 +73,7 @@ nfs_shared_folder: /opt
 mesos_cloned_folder: mesos
 myriad_cloned_folder: myriad
 mesos_repository: https://gitbox.apache.org/repos/asf/mesos.git
-myriad_repository: https://github.com/myriad-framework/myriad
+myriad_repository: https://github.com/apache/incubator-myriad
 mesos_repo_branch: master
 myriad_repo_branch: master
 


### PR DESCRIPTION
Vagrant Ansible provisioning is pointing to old repository.

JIRA:
    [MYRIAD-281] https://issues.apache.org/jira/browse/MYRIAD-281