### PR TITLE
MYRIAD-289 Fix prepare_rc.sh with new GIT_URL

### DIFF
--- a/support/apache-release/prepare_rc.sh
+++ b/support/apache-release/prepare_rc.sh
@@ -28,7 +28,7 @@ VERSION=${1}
 RC=${2}
 
 TAG="myriad-${VERSION}-incubating-rc${RC}"
-GIT_URL="https://git-wip-us.apache.org/repos/asf/incubator-myriad.git"
+GIT_URL=" https://github.com/apache/incubator-myriad.git"
 WORK_DIR="."
 
 echo "Preparing a release candidate ${TAG}.."


### PR DESCRIPTION
We have to update GIT_URL at prepare_rc.sh support script. For
Apache Myriad v0.3.0 releasing.