### PR TITLE
MYRIAD-290 prepare_rc.sh fails with TAR error message

### DIFF
--- a/support/apache-release/prepare_rc.sh
+++ b/support/apache-release/prepare_rc.sh
@@ -64,7 +64,7 @@ rm -rf ${TAG}/myriad-scheduler/src/main/resources/banner.txt
 
 # Create a tar ball that excludes VCS files
 TARBALL=${TAG}.tar.gz
-tar -czf ${TARBALL} ${TAG} --exclude-vcs || \
+tar czf ${TARBALL} --exclude-vcs ${TAG} || \
   { echo "Failed to create a tarball of ${TAG}"; exit 1; }
 
 # Sign the tarball.


### PR DESCRIPTION
In newer versions of tar the paremeter --exclude-vcs is position-sensitive.
So the current prepare_rc.sh fails with message:

tar: The following options were used after any non-optional ...
tar: --exclude-vcs has no effect
tar: Exiting with failure status due to previous errors